### PR TITLE
Fixes Decrypt with No Password

### DIFF
--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -3,17 +3,18 @@ import execute from "./spawn";
 
 export default async (
   input: string,
-  password: string,
+  password?: string,
   output?: string
 ): Promise<string> => {
   if (!input) return "Please specify input file";
-  if (!password) return "Password missing";
   if (!fileExists(input)) return "Input file doesn't exist";
 
   const callArguments = ["--decrypt"];
 
   // Password
-  callArguments.push(`--password=${password}`);
+  if(password){
+    callArguments.push(`--password=${password}`);
+  }
 
   // Input file path
   callArguments.push(input);

--- a/test/decrypt.js
+++ b/test/decrypt.js
@@ -55,16 +55,6 @@ test("should not work if no input file is specified for decrypt", async (t) => {
   }
 });
 
-test("should not work if no password entered for decrypt", async (t) => {
-  try {
-    const results = await qpdf.decrypt("test/file-to-file.pdf", "");
-    if (results === "Password missing") {
-      t.pass();
-    }
-  } catch {
-    t.fail();
-  }
-});
 
 test.todo("Should decrypt a File -> Buffer");
 


### PR DESCRIPTION
Removed Contradicting test. There are two tests, one checking for success when decrypting without a password, the other checking for failure when decrypting without a password.  The first is passing errantly as it is not checking the output, instead expecting an error that is never thrown. The second test, for failure is removed as it is not an intended use case.

Made password optional in call. Removed the password check and conditionally adds the password to command line 