### PR TITLE
feat: add option to decrypt without password

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ const options = {
 await decrypt(options);
 ```
 
+ By default if you don't provide a password `""` is sent as the password. If you want to remove this password while decryption, you can send `ignorePassword` inside the options object.
+ You can decrypt your PDF by following:
+```
+import { decrypt } from "node-qpdf2";
+
+const options = {
+  input: "/tmp/encrypted.pdf",
+  output: "/tmp/decrypted.pdf",
+  ignorePassword: true,
+}
+
+await decrypt(options);
+```
+
+This is useful when the PDF is protected by an owner password instead of a user password.
+
 ## Coverage
 ------------|---------|----------|---------|---------|-------------------
 File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s

--- a/src/decrypt.ts
+++ b/src/decrypt.ts
@@ -5,6 +5,7 @@ export interface DecryptSettings {
   input: string;
   output?: string;
   password?: string;
+  ignorePassword?: boolean;
 }
 
 export default async (payload: DecryptSettings): Promise<Buffer> => {
@@ -13,11 +14,13 @@ export default async (payload: DecryptSettings): Promise<Buffer> => {
 
   const callArguments = ["--decrypt"];
 
-  // Password
-  if (payload.password) {
-    callArguments.push(`--password=${payload.password}`);
-  } else {
-    callArguments.push('--password=""');
+  if(!payload.ignorePassword){
+    // Password
+    if (payload.password) {
+      callArguments.push(`--password=${payload.password}`);
+    } else {
+      callArguments.push('--password=""');
+    }
   }
 
   // Input file path


### PR DESCRIPTION
Sometimes, downloaded pdf (such as your bank statements) are secured/encrypted by default. We can decrypt this even without OWNER password using `qpdf`. 

`qpdf --decrypt <source-pdf> <destination-pdf>`

By using the `ignorePassword` prop in payload, we can remove the password from the process call. Didn't change the default procedure of sending `""` as password to maintain backwards compatibility.